### PR TITLE
Fix cart item update via user and card

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -461,8 +461,33 @@ def update_cart_item(cart_item_id, cart_item_data):
         db.session.commit()
     return cart_item
 
+
+def update_cart_item_by_user_and_card(user_id, card_id, quantity):
+    """Update quantity of a cart item identified by user and card.
+
+    If the cart item does not exist, a new record is created with the
+    provided quantity.
+    """
+    cart_item = CartItem.query.filter_by(user_id=user_id, card_id=card_id).first()
+    if cart_item:
+        cart_item.quantity = quantity
+    else:
+        cart_item = CartItem(user_id=user_id, card_id=card_id, quantity=quantity)
+        db.session.add(cart_item)
+    db.session.commit()
+    return cart_item
+
 def delete_cart_item(cart_item_id):
     cart_item = db.session.get(CartItem, cart_item_id)
+    if cart_item:
+        db.session.delete(cart_item)
+        db.session.commit()
+    return cart_item
+
+
+def delete_cart_item_by_user_and_card(user_id, card_id):
+    """Delete a cart item based on user and card identifiers."""
+    cart_item = CartItem.query.filter_by(user_id=user_id, card_id=card_id).first()
     if cart_item:
         db.session.delete(cart_item)
         db.session.commit()

--- a/backend/app/routers/orders.py
+++ b/backend/app/routers/orders.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from ..utils import admin_required
 from ..crud import (
     create_order, get_all_orders, get_order_by_id, get_order_filter_options, get_user_orders, search_orders, update_order, delete_order,
-    update_cart_item, delete_cart_item, get_cart_items, clear_cart, create_payment
+    update_cart_item_by_user_and_card, delete_cart_item_by_user_and_card, get_cart_items, clear_cart, create_payment
 )
 from ..schemas import OrderSchema
 from ..models import Card
@@ -58,7 +58,7 @@ def update_cart_item_route(card_id):
     try:
         user_id = get_jwt_identity()
         quantity = request.json['quantity']
-        update_cart_item(user_id, card_id, quantity)
+        update_cart_item_by_user_and_card(user_id, card_id, quantity)
         return jsonify({'message': 'Cart item updated'}), 200
     except ValidationError as e:
         return jsonify(e.errors()), 400
@@ -70,7 +70,7 @@ def update_cart_item_route(card_id):
 def delete_cart_item_route(card_id):
     try:
         user_id = get_jwt_identity()
-        delete_cart_item(user_id, card_id)
+        delete_cart_item_by_user_and_card(user_id, card_id)
         return jsonify({'message': 'Cart item deleted'}), 200
     except ValidationError as e:
         return jsonify(e.errors()), 400


### PR DESCRIPTION
## Summary
- add helper functions `update_cart_item_by_user_and_card` and `delete_cart_item_by_user_and_card`
- use new helpers in the order routes so cart items update correctly

## Testing
- `pytest -q` *(fails: InterfaceError: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_684b598835008326b4045ad2dd1f1b03